### PR TITLE
update build-instructions page

### DIFF
--- a/src/build-instructions.md
+++ b/src/build-instructions.md
@@ -68,9 +68,9 @@ For Ubuntu 20.04, also install `python2`.
   $ sudo dnf install make cmake clang bison dbus-devel flex python2 glibc-devel.i686 fuse-devel \
   systemd-devel kernel-devel elfutils-libelf-devel cairo-devel freetype-devel.{x86_64,i686} \
   libjpeg-turbo-devel.{x86_64,i686} libtiff-devel.{x86_64,i686} fontconfig-devel.{x86_64,i686} \
-  libglvnd-devel.{x86_64,i686} mesa-libGL-devel.{x86_64,i686} mesa-libEGL-devel.{x86_64,i686} \
-  libxml2-devel libbsd-devel git libXcursor-devel libXrandr-devel giflib-devel ffmpeg-devel \
-  pulseaudio-libs-devel libxkbfile-devel llvm
+  libglvnd-devel.{x86_64,i686} mesa-libGL-devel.{x86_64,i686} mesa-libGLU-devel.{x86_64,i686} \
+  mesa-libEGL-devel.{x86_64,i686} libxml2-devel libbsd-devel git libXcursor-devel libXrandr-devel \
+  giflib-devel ffmpeg-devel pulseaudio-libs-devel libxkbfile-devel llvm
   ```
 
 


### PR DESCRIPTION
add mesa-libGLU-devel 64 and 32 bit packages as Fedora/CentOS build dependencies 

This was needed to build on a Fedora 32 machine.